### PR TITLE
Added .call(this) to megapixel lib

### DIFF
--- a/source/js/3rdparty/ios-imagefile-megapixel.js
+++ b/source/js/3rdparty/ios-imagefile-megapixel.js
@@ -271,4 +271,4 @@
         this.MegaPixImage = MegaPixImage;
     }
 
-})();
+}.call(this));


### PR DESCRIPTION
Megapixel 3rd party lib fails when running in strict mode [here](https://github.com/CrackerakiUA/ui-cropper/blob/master/source/js/3rdparty/ios-imagefile-megapixel.js#L271) as `this` is undefined in strict mode. Correct `this` context is passed using the call method.