### PR TITLE
Fixed result-image-format incorrectly setting the result-image type

### DIFF
--- a/source/js/ui-cropper.js
+++ b/source/js/ui-cropper.js
@@ -33,7 +33,7 @@ angular.module('uiCropper').directive('uiCropper', ['$timeout', 'cropHost', 'cro
             /* if canvas is 100x100 crop coordinates will be x: 10, y: 10, w: 10, h: 10 */
             areaMinRelativeSize: '=?',
             resultImageSize: '=?',
-            resultImageFormat: '=?',
+            resultImageFormat: '@',
             resultImageQuality: '=?',
 
             aspectRatio: '=?',


### PR DESCRIPTION
- changed the directive binding declaration from resultImageFormat: "=?" to resultImageFormat: "@"