### PR TITLE
Fixed canvas size

### DIFF
--- a/compile/unminified/ui-cropper.js
+++ b/compile/unminified/ui-cropper.js
@@ -2,10 +2,10 @@
  * uiCropper v1.0.4
  * https://crackerakiua.github.io/ui-cropper/
  *
- * Copyright (c) 2016 Alex Kaul
+ * Copyright (c) 2017 Alex Kaul
  * License: MIT
  *
- * Generated at Friday, December 23rd, 2016, 3:05:21 PM
+ * Generated at Friday, July 14th, 2017, 10:41:23 AM
  */
 (function() {
 angular.module('uiCropper', []);
@@ -2408,14 +2408,8 @@ angular.module('uiCropper').factory('cropHost', ['$document', '$q', 'cropAreaCir
             }
         };
 
-        var renderImageToDataURL = function (getResultImageSize) {
-            var temp_ctx, temp_canvas,
-                ris = getResultImageSize,
-                center = theArea.getCenterPoint(),
-                retObj = {
-                    dataURI: null,
-                    imageData: null
-                };
+        var renderTempCanvas = function (ris, center) {
+            var temp_ctx, temp_canvas;
             temp_canvas = angular.element('<canvas></canvas>')[0];
             temp_ctx = temp_canvas.getContext('2d');
             temp_canvas.width = ris.w;
@@ -2446,6 +2440,9 @@ angular.module('uiCropper').factory('cropHost', ['$document', '$q', 'cropAreaCir
                         resultWidth = resultHeight * aspectRatio;
                     }
 
+                    temp_canvas.width = resultWidth;
+                    temp_canvas.height = resultHeight;
+
                     temp_ctx.drawImage(image,
                         x,
                         y,
@@ -2457,6 +2454,19 @@ angular.module('uiCropper').factory('cropHost', ['$document', '$q', 'cropAreaCir
                         Math.round(resultHeight));
                 }
 
+            }
+            return temp_canvas;
+
+        };
+
+        var renderImageToDataURL = function (getResultImageSize) {
+            var temp_canvas,
+                retObj = {
+                    dataURI: null,
+                    imageData: null
+                };
+            temp_canvas = renderTempCanvas(getResultImageSize, theArea.getCenterPoint());
+            if (image !== null) {
                 if (resImgQuality !== null) {
                     retObj.dataURI = temp_canvas.toDataURL(resImgFormat, resImgQuality);
                 } else {
@@ -2484,52 +2494,9 @@ angular.module('uiCropper').factory('cropHost', ['$document', '$q', 'cropAreaCir
         };
 
         this.getResultImageDataBlob = function () {
-            var temp_ctx, temp_canvas,
-                center = theArea.getCenterPoint(),
-                ris = this.getResultImageSize(),
+            var temp_canvas,
                 _p = $q.defer();
-            temp_canvas = angular.element('<canvas></canvas>')[0];
-            temp_ctx = temp_canvas.getContext('2d');
-            temp_canvas.width = ris.w;
-            temp_canvas.height = ris.h;
-            if (image !== null) {
-                var x = (center.x - theArea.getSize().w / 2) * (image.width / ctx.canvas.width),
-                    y = (center.y - theArea.getSize().h / 2) * (image.height / ctx.canvas.height),
-                    areaWidth = theArea.getSize().w * (image.width / ctx.canvas.width),
-                    areaHeight = theArea.getSize().h * (image.height / ctx.canvas.height);
-
-                if (forceAspectRatio) {
-                    temp_ctx.drawImage(image, x, y,
-                        areaWidth,
-                        areaHeight,
-                        0,
-                        0,
-                        ris.w,
-                        ris.h);
-                } else {
-                    var aspectRatio = areaWidth / areaHeight;
-                    var resultHeight, resultWidth;
-
-                    if (aspectRatio > 1) {
-                        resultWidth = ris.w;
-                        resultHeight = resultWidth / aspectRatio;
-                    } else {
-                        resultHeight = ris.h;
-                        resultWidth = resultHeight * aspectRatio;
-                    }
-
-                    temp_ctx.drawImage(image,
-                        x,
-                        y,
-                        areaWidth,
-                        areaHeight,
-                        0,
-                        0,
-                        Math.round(resultWidth),
-                        Math.round(resultHeight));
-                }
-            }
-
+            temp_canvas = renderTempCanvas(this.getResultImageSize(), theArea.getCenterPoint());
             if (resImgQuality !== null) {
                 temp_canvas.toBlob(function (blob) {
                     _p.resolve(blob);
@@ -3104,7 +3071,7 @@ angular.module('uiCropper').directive('uiCropper', ['$timeout', 'cropHost', 'cro
             /* if canvas is 100x100 crop coordinates will be x: 10, y: 10, w: 10, h: 10 */
             areaMinRelativeSize: '=?',
             resultImageSize: '=?',
-            resultImageFormat: '=?',
+            resultImageFormat: '@',
             resultImageQuality: '=?',
 
             aspectRatio: '=?',
@@ -3285,7 +3252,7 @@ angular.module('uiCropper').directive('uiCropper', ['$timeout', 'cropHost', 'cro
                     scope.onLoadError({});
                 }))
                 .on('area-move area-resize', fnSafeApply(function (scope) {
-                    if (scope.changeOnFly === 'true') {
+                    if (scope.changeOnFly === true) {
                         updateResultImage(scope);
                     }
                     updateCropject(scope);

--- a/source/js/classes/crop-host.js
+++ b/source/js/classes/crop-host.js
@@ -277,6 +277,9 @@ angular.module('uiCropper').factory('cropHost', ['$document', '$q', 'cropAreaCir
                         resultWidth = resultHeight * aspectRatio;
                     }
 
+                    temp_canvas.width = resultWidth;
+                    temp_canvas.height = resultHeight;
+
                     temp_ctx.drawImage(image,
                         x,
                         y,

--- a/source/js/classes/crop-host.js
+++ b/source/js/classes/crop-host.js
@@ -245,14 +245,8 @@ angular.module('uiCropper').factory('cropHost', ['$document', '$q', 'cropAreaCir
             }
         };
 
-        var renderImageToDataURL = function (getResultImageSize) {
-            var temp_ctx, temp_canvas,
-                ris = getResultImageSize,
-                center = theArea.getCenterPoint(),
-                retObj = {
-                    dataURI: null,
-                    imageData: null
-                };
+        var renderTempCanvas = function (ris, center) {
+            var temp_ctx, temp_canvas;
             temp_canvas = angular.element('<canvas></canvas>')[0];
             temp_ctx = temp_canvas.getContext('2d');
             temp_canvas.width = ris.w;
@@ -294,6 +288,19 @@ angular.module('uiCropper').factory('cropHost', ['$document', '$q', 'cropAreaCir
                         Math.round(resultHeight));
                 }
 
+            }
+            return temp_canvas;
+
+        };
+
+        var renderImageToDataURL = function (getResultImageSize) {
+            var temp_canvas,
+                retObj = {
+                    dataURI: null,
+                    imageData: null
+                };
+            temp_canvas = renderTempCanvas(getResultImageSize, theArea.getCenterPoint());
+            if (image !== null) {
                 if (resImgQuality !== null) {
                     retObj.dataURI = temp_canvas.toDataURL(resImgFormat, resImgQuality);
                 } else {
@@ -321,52 +328,9 @@ angular.module('uiCropper').factory('cropHost', ['$document', '$q', 'cropAreaCir
         };
 
         this.getResultImageDataBlob = function () {
-            var temp_ctx, temp_canvas,
-                center = theArea.getCenterPoint(),
-                ris = this.getResultImageSize(),
+            var temp_canvas,
                 _p = $q.defer();
-            temp_canvas = angular.element('<canvas></canvas>')[0];
-            temp_ctx = temp_canvas.getContext('2d');
-            temp_canvas.width = ris.w;
-            temp_canvas.height = ris.h;
-            if (image !== null) {
-                var x = (center.x - theArea.getSize().w / 2) * (image.width / ctx.canvas.width),
-                    y = (center.y - theArea.getSize().h / 2) * (image.height / ctx.canvas.height),
-                    areaWidth = theArea.getSize().w * (image.width / ctx.canvas.width),
-                    areaHeight = theArea.getSize().h * (image.height / ctx.canvas.height);
-
-                if (forceAspectRatio) {
-                    temp_ctx.drawImage(image, x, y,
-                        areaWidth,
-                        areaHeight,
-                        0,
-                        0,
-                        ris.w,
-                        ris.h);
-                } else {
-                    var aspectRatio = areaWidth / areaHeight;
-                    var resultHeight, resultWidth;
-
-                    if (aspectRatio > 1) {
-                        resultWidth = ris.w;
-                        resultHeight = resultWidth / aspectRatio;
-                    } else {
-                        resultHeight = ris.h;
-                        resultWidth = resultHeight * aspectRatio;
-                    }
-
-                    temp_ctx.drawImage(image,
-                        x,
-                        y,
-                        areaWidth,
-                        areaHeight,
-                        0,
-                        0,
-                        Math.round(resultWidth),
-                        Math.round(resultHeight));
-                }
-            }
-
+            temp_canvas = renderTempCanvas(this.getResultImageSize(), theArea.getCenterPoint());
             if (resImgQuality !== null) {
                 temp_canvas.toBlob(function (blob) {
                     _p.resolve(blob);


### PR DESCRIPTION
This fixes the canvas size that was always square, now it adapts to the resulting image ratio. It also moves the temp canvas creation into a new function to remove the duplicated code for the Blob and DataURI images. Fixes issue #22 