### PR TITLE
Accessibility: add keyboard support

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -56,6 +56,7 @@
                     result-image-size="resImgSize"
                     aspect-ratio="aspectRatio"
                     allow-crop-resize-on-corners="false"
+                    disable-keyboard-access="false"
                     init-max-area="true"
                     chargement="'Testing Message'"
                     on-change="onChange($dataURI)"

--- a/source/js/classes/crop-area-circle.js
+++ b/source/js/classes/crop-area-circle.js
@@ -68,7 +68,7 @@ angular.module('uiCropper').factory('cropAreaCircle', ['cropArea', function(Crop
         this._cropCanvas.drawIconResizeBoxNESW(this._calcResizeIconCenterCoords(), this._boxResizeBaseSize, this._boxResizeIsHover ? this._boxResizeHoverRatio : this._boxResizeNormalRatio);
     };
 
-    CropAreaCircle.prototype.setSizeByScale = function(scale, direction) {
+    CropAreaCircle.prototype.setSizeByScale = function(scale) {
         var center = this.getCenterPoint();
         var size = this.getSize();
         var newRadius = size.w * scale / 2;

--- a/source/js/classes/crop-area-circle.js
+++ b/source/js/classes/crop-area-circle.js
@@ -68,6 +68,22 @@ angular.module('uiCropper').factory('cropAreaCircle', ['cropArea', function(Crop
         this._cropCanvas.drawIconResizeBoxNESW(this._calcResizeIconCenterCoords(), this._boxResizeBaseSize, this._boxResizeIsHover ? this._boxResizeHoverRatio : this._boxResizeNormalRatio);
     };
 
+    CropAreaCircle.prototype.setSizeByScale = function(scale, direction) {
+        var center = this.getCenterPoint();
+        var size = this.getSize();
+        var newRadius = size.w * scale / 2;
+        var northWestPoint = {
+            x: center.x - newRadius,
+            y: center.y - newRadius
+        };
+        var southEastPoint = {
+            x: center.x + newRadius,
+            y: center.y + newRadius
+        };
+        this.circleOnMove(northWestPoint, southEastPoint);
+        this._events.trigger('area-resize');
+    };
+
     CropAreaCircle.prototype.processMouseMove = function(mouseCurX, mouseCurY) {
         var cursor = 'default';
         var res = false;

--- a/source/js/classes/crop-area-rectangle.js
+++ b/source/js/classes/crop-area-rectangle.js
@@ -95,6 +95,48 @@ angular.module('uiCropper').factory('cropAreaRectangle', ['cropArea', function (
         }
     };
 
+    CropAreaRectangle.prototype.setSizeByScale = function(scale, direction) {
+        var center = this.getCenterPoint();
+        var size = this.getSize();
+        var northWestPoint;
+        var southEastPoint;
+
+        if (this._aspect) {
+            var newWidth = size.w * scale;
+            var newHeight = size.h * scale;
+            northWestPoint = {
+                x: center.x - (newWidth / 2),
+                y: center.y - (newHeight / 2)
+            };
+            southEastPoint = {
+                x: center.x + (newWidth / 2),
+                y: center.y + (newHeight / 2)
+            };
+        } else {
+            northWestPoint = {
+                x: size.x,
+                y: size.y
+            };
+            southEastPoint = {
+                x: size.x + size.w,
+                y: size.y + size.h
+            };
+            switch (direction) {
+                case 'up':
+                case 'down':
+                    southEastPoint.y = size.y + (size.h * scale);
+                    break;
+                case 'left':
+                case 'right':
+                    southEastPoint.x = size.x + (size.w * scale);
+                    break;
+            }
+        }
+
+        this.setSizeByCorners(northWestPoint, southEastPoint);
+        this._events.trigger('area-resize');
+    };
+
     CropAreaRectangle.prototype.processMouseMove = function (mouseCurX, mouseCurY) {
         var cursor = 'default';
         var res = false;

--- a/source/js/classes/crop-area-square.js
+++ b/source/js/classes/crop-area-square.js
@@ -120,6 +120,25 @@ angular.module('uiCropper').factory('cropAreaSquare', ['cropArea', function(Crop
         };
     };
 
+    CropAreaSquare.prototype.setSizeByScale = function(scale, direction) {
+        var center = this.getCenterPoint();
+        var size = this.getSize();
+        var newSize = size.w * scale;
+        if (newSize < this._minSize.w) {
+            newSize = this._minSize.w;
+        }
+        var northWestPoint = {
+            x: center.x - (newSize / 2),
+            y: center.y - (newSize / 2)
+        };
+        var southEastPoint = {
+            x: center.x + (newSize / 2),
+            y: center.y + (newSize / 2)
+        };
+        this.setSizeByCorners(northWestPoint, southEastPoint);
+        this._events.trigger('area-resize');
+    };
+
     CropAreaSquare.prototype.processMouseMove = function(mouseCurX, mouseCurY) {
         var cursor = 'default';
         var res = false;

--- a/source/js/classes/crop-area-square.js
+++ b/source/js/classes/crop-area-square.js
@@ -120,7 +120,7 @@ angular.module('uiCropper').factory('cropAreaSquare', ['cropArea', function(Crop
         };
     };
 
-    CropAreaSquare.prototype.setSizeByScale = function(scale, direction) {
+    CropAreaSquare.prototype.setSizeByScale = function(scale) {
         var center = this.getCenterPoint();
         var size = this.getSize();
         var newSize = size.w * scale;

--- a/source/js/classes/crop-host.js
+++ b/source/js/classes/crop-host.js
@@ -91,6 +91,7 @@ angular.module('uiCropper').factory('cropHost', ['$document', '$q', 'cropAreaCir
         // Resets CropHost
         var resetCropHost = function () {
             if (image !== null) {
+                focusOnCanvas();
                 theArea.setImage(image);
                 var imageDims = [image.width, image.height],
                     imageRatio = image.width / image.height,
@@ -206,6 +207,7 @@ angular.module('uiCropper').factory('cropHost', ['$document', '$q', 'cropAreaCir
                     pageX = e.pageX;
                     pageY = e.pageY;
                 }
+
                 theArea.processMouseMove(pageX - offset.left, pageY - offset.top);
                 drawScene();
             }
@@ -215,6 +217,7 @@ angular.module('uiCropper').factory('cropHost', ['$document', '$q', 'cropAreaCir
             e.preventDefault();
             e.stopPropagation();
             if (image !== null) {
+                focusOnCanvas();
                 var offset = getElementOffset(ctx.canvas),
                     pageX, pageY;
                 if (e.type === 'touchstart') {
@@ -243,6 +246,10 @@ angular.module('uiCropper').factory('cropHost', ['$document', '$q', 'cropAreaCir
                 theArea.processMouseUp(pageX - offset.left, pageY - offset.top);
                 drawScene();
             }
+        };
+
+        var focusOnCanvas = function () {
+            elCanvas.focus();
         };
 
         var renderTempCanvas = function (ris, center) {
@@ -836,6 +843,8 @@ angular.module('uiCropper').factory('cropHost', ['$document', '$q', 'cropAreaCir
         $document.on('touchmove', onMouseMove);
         elCanvas.on('touchstart', onMouseDown);
         $document.on('touchend', onMouseUp);
+
+        elCanvas.prop('tabindex', '0');
 
         // CropHost Destructor
         this.destroy = function () {

--- a/source/js/classes/crop-host.js
+++ b/source/js/classes/crop-host.js
@@ -98,6 +98,10 @@ angular.module('uiCropper').factory('cropHost', ['$document', '$q', 'cropAreaCir
             }
         }
 
+        var focusOnCanvas = function () {
+            elCanvas.focus();
+        };
+
         // Resets CropHost
         var resetCropHost = function () {
             if (image !== null) {
@@ -258,29 +262,6 @@ angular.module('uiCropper').factory('cropHost', ['$document', '$q', 'cropAreaCir
             }
         };
 
-        var onKeyDown = function (e) {
-            if (image !== null && opts.disableKeyboardAccess !== true) {
-                var key = e.which;
-                switch (key) {
-                    case keys.up:
-                    case keys.down:
-                    case keys.left:
-                    case keys.right:
-                        e.preventDefault();
-                        e.stopPropagation();
-                        var direction = getDirectionByKey(key);
-                        if (e.shiftKey) {
-                            resizeCropAreaByDirection(direction);
-                        } else {
-                            moveCropArea(direction);
-                        }
-                        break;
-                    default:
-                        return;
-                }
-            }
-        };
-
         var getDirectionByKey = function (key) {
             return Object.keys(keys).reduce(function(result, direction) {
                 return key === keys[direction] ? direction : result;
@@ -332,10 +313,29 @@ angular.module('uiCropper').factory('cropHost', ['$document', '$q', 'cropAreaCir
 
             theArea.setCenterPointOnMove(point);
             drawScene();
-        }
+        };
 
-        var focusOnCanvas = function () {
-            elCanvas.focus();
+        var onKeyDown = function (e) {
+            if (image !== null && opts.disableKeyboardAccess !== true) {
+                var key = e.which;
+                switch (key) {
+                    case keys.up:
+                    case keys.down:
+                    case keys.left:
+                    case keys.right:
+                        e.preventDefault();
+                        e.stopPropagation();
+                        var direction = getDirectionByKey(key);
+                        if (e.shiftKey) {
+                            resizeCropAreaByDirection(direction);
+                        } else {
+                            moveCropArea(direction);
+                        }
+                        break;
+                    default:
+                        return;
+                }
+            }
         };
 
         var renderTempCanvas = function (ris, center) {

--- a/source/js/classes/crop-host.js
+++ b/source/js/classes/crop-host.js
@@ -269,7 +269,11 @@ angular.module('uiCropper').factory('cropHost', ['$document', '$q', 'cropAreaCir
                         e.preventDefault();
                         e.stopPropagation();
                         var direction = getDirectionByKey(key);
-                        moveCropArea(direction);
+                        if (e.shiftKey) {
+                            resizeCropAreaByDirection(direction);
+                        } else {
+                            moveCropArea(direction);
+                        }
                         break;
                     default:
                         return;
@@ -281,6 +285,24 @@ angular.module('uiCropper').factory('cropHost', ['$document', '$q', 'cropAreaCir
             return Object.keys(keys).reduce(function(result, direction) {
                 return key === keys[direction] ? direction : result;
             }, null);
+        };
+
+        var resizeCropAreaByDirection = function (direction) {
+            var scale;
+            switch (direction) {
+                case 'up':
+                case 'left':
+                    scale = 0.95;
+                    break;
+                case 'down':
+                case 'right':
+                    scale = 1.05;
+                    break;
+                default:
+                    return;
+            }
+            theArea.setSizeByScale(scale, direction);
+            drawScene();
         };
 
         var moveCropArea = function (direction) {

--- a/source/js/ui-cropper.js
+++ b/source/js/ui-cropper.js
@@ -18,6 +18,7 @@ angular.module('uiCropper').directive('uiCropper', ['$timeout', 'cropHost', 'cro
             /* if set to 'fixed-height', the directive is restricted by a parent element in height */
 
             changeOnFly: '=?',
+            disableKeyboardAccess: '=?',
             liveView: '=?',
             initMaxArea: '=?',
             areaCoords: '=?',

--- a/source/js/ui-cropper.js
+++ b/source/js/ui-cropper.js
@@ -58,7 +58,9 @@ angular.module('uiCropper').directive('uiCropper', ['$timeout', 'cropHost', 'cro
             var events = scope.events;
 
             // Init Crop Host
-            var cropHost = new CropHost(element.find('canvas'), {}, events);
+            var cropHost = new CropHost(element.find('canvas'), {
+                disableKeyboardAccess: scope.disableKeyboardAccess
+            }, events);
 
             if (scope.canvasScalemode) {
                 cropHost.setScalemode(scope.canvasScalemode);
@@ -183,7 +185,7 @@ angular.module('uiCropper').directive('uiCropper', ['$timeout', 'cropHost', 'cro
                     case 'de':
                     case 'de-DE':
                         return 'Laden';
-                        
+
                     case 'pt':
                     case 'pt-BR':
                         return 'Carregando';


### PR DESCRIPTION
This PR makes the canvas focusable and adds support for editing the crop area with a keyboard. This entire feature can be toggled on/off with the new input `disableKeyboardAccess`. I am using this plugin for a project and would like for it to meet our accessibility standards.

When an image is uploaded or when the mousedown event occurs, focus is placed on the canvas element. A tabindex of 0 has also been added to the canvas so the user can reach it via tabbing. When the canvas is in focus, the arrow keys will move the crop area around in steps of 5px. Using the arrow keys with the shift key will resize the area in steps of 5% of the current size. Circular crops, square crops, and rectangular crops with an aspect ratio will resize from the center and lock the aspect ratio. Rectangular crops without an aspect ratio will resize from the top left corner and allow for the aspect ratio to change.

Here is a screen recording of the feature in action on the demo page:
![dhxc0ejeau](https://user-images.githubusercontent.com/1933201/34011479-24e17fe0-e0de-11e7-97b6-e33e05c9e197.gif)

Let me know what you think and if I have missed any secondary functionality like firing events. Thanks!