### PR TITLE
Changing aspectRatio parse from int to float

### DIFF
--- a/source/js/ui-cropper.js
+++ b/source/js/ui-cropper.js
@@ -297,7 +297,7 @@ angular.module('uiCropper').directive('uiCropper', ['$timeout', 'cropHost', 'cro
             });
             scope.$watch('aspectRatio', function () {
                 if (typeof scope.aspectRatio === 'string' && scope.aspectRatio !== '') {
-                    scope.aspectRatio = parseInt(scope.aspectRatio);
+                    scope.aspectRatio = parseFloat(scope.aspectRatio);
                 }
                 if (scope.aspectRatio) {
                     cropHost.setAspect(scope.aspectRatio);


### PR DESCRIPTION
This allows usage of more common aspect ratios like 1.77 (16:9) and 1.33 (4:3)

Currently parseInt strips the decimals from the passed aspectRatio