### PR TITLE
allow reset of aspect ratio

### DIFF
--- a/source/js/ui-cropper.js
+++ b/source/js/ui-cropper.js
@@ -310,6 +310,8 @@ angular.module('uiCropper').directive('uiCropper', ['$timeout', 'cropHost', 'cro
                 }
                 if (scope.aspectRatio) {
                     cropHost.setAspect(scope.aspectRatio);
+                } else {
+                    cropHost.setAspect('');
                 }
             });
             scope.$watch('allowCropResizeOnCorners', function () {


### PR DESCRIPTION
When null or empty string is provided the value should be passed to cropHost.setAspect() as well, not just if the statement resolves in true.

this closes #41 